### PR TITLE
Add cursor support

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -6,7 +6,7 @@
 'use strict'
 
 const { ifError } = require('assert')
-const { bulkMix } = require('./mixins')
+const { bulkMix, cursorMix } = require('./mixins')
 const { validateDriver } = require('./validating')
 
 let notImplementedError = () => new Error('Not implemented!')
@@ -92,6 +92,7 @@ class Driver {
 }
 
 module.exports = [
+  cursorMix,
   bulkMix
 ].reduce((Driver, mixin) => mixin(Driver), Driver)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 /**
  * Base driver for clay
  * @module clay-driver-base
- * @version 1.0.3
+ * @version 1.0.4
  */
 
 'use strict'

--- a/lib/mixins/bulk_mix.js
+++ b/lib/mixins/bulk_mix.js
@@ -17,16 +17,16 @@ function bulkMixin (BaseClass) {
 
     /**
      * One as bulk
-     * @param {string} namespace - Namepath string
+     * @param {string} resourceName - Name of resource
      * @param {ClayId[]} ids - Resource ids
      * @returns {Promise.<Object.<ClayId, ClayEntity>>} Found resources
      */
-    oneBulk (namespace, ids) {
+    oneBulk (resourceName, ids) {
       const s = this
       return co(function * () {
         let found = {}
         for (let id of ids) {
-          found[ String(id) ] = yield s.one(namespace, id)
+          found[ String(id) ] = yield s.one(resourceName, id)
         }
         return found
       })
@@ -34,18 +34,18 @@ function bulkMixin (BaseClass) {
 
     /**
      * List with multiple conditions
-     * @param {string} namespace - Namepath string
+     * @param {string} resourceName - Name of resource
      * @param {ListCondition[]} conditionArray
      * @returns {Promise.<ClayCollection[]>} Found resource collections
      */
-    listBulk (namespace, conditionArray) {
+    listBulk (resourceName, conditionArray) {
       const s = this
       return co(function * () {
         let found = []
         for (let condition of conditionArray) {
           found = [
             ...found,
-            yield s.list(namespace, condition)
+            yield s.list(resourceName, condition)
           ]
         }
         return found
@@ -54,17 +54,17 @@ function bulkMixin (BaseClass) {
 
     /**
      * Create multiple resources
-     * @param {string} namespace - Namepath string
+     * @param {string} resourceName - Name of resource
      * @param {Object[]} attributesArray - List of attributes
      * @returns {Promise.<ClayEntity[]>} Created resources
      */
-    createBulk (namespace, attributesArray) {
+    createBulk (resourceName, attributesArray) {
       const s = this
       return co(function * () {
         let created = []
         for (let attributes of attributesArray) {
           created.push(
-            yield Promise.resolve(s.create(namespace, attributes))
+            yield Promise.resolve(s.create(resourceName, attributes))
           )
         }
         return created
@@ -73,17 +73,17 @@ function bulkMixin (BaseClass) {
 
     /**
      * Update multiple resources
-     * @param {string} namespace - Namepath string
+     * @param {string} resourceName - Name of resource
      * @param {Object.<ClayId, Object>} attributesHash - Hash of attributes
      * @returns {Promise.<Object.<ClayId, ClayEntity>>} Updated resources
      */
-    updateBulk (namespace, attributesHash) {
+    updateBulk (resourceName, attributesHash) {
       const s = this
       return co(function * () {
         let updated = []
         for (let id of Object.keys(attributesHash)) {
           let attributes = attributesHash[ id ]
-          updated[ id ] = yield Promise.resolve(s.update(namespace, id, attributes))
+          updated[ id ] = yield Promise.resolve(s.update(resourceName, id, attributes))
         }
         return updated
       })
@@ -91,16 +91,16 @@ function bulkMixin (BaseClass) {
 
     /**
      * Update multiple resources
-     * @param {string} namespace - Namepath string
+     * @param {string} resourceName - Name of resource
      * @param {ClayId[]} ids - Ids to destroy
      * @returns {Promise.<number>} Destroyed counts
      */
-    destroyBulk (namespace, ids) {
+    destroyBulk (resourceName, ids) {
       const s = this
       return co(function * () {
         let count = 0
         for (let id of ids) {
-          count += yield Promise.resolve(s.destroy(namespace, id))
+          count += yield Promise.resolve(s.destroy(resourceName, id))
         }
         return count
       })

--- a/lib/mixins/cursor_mix.js
+++ b/lib/mixins/cursor_mix.js
@@ -1,0 +1,57 @@
+/**
+ * Mixin to cursor support
+ * @function cursorMixin
+ * @param {function} BaseClass - Class to mix
+ * @returns {function} Mixed class
+ */
+'use strict'
+
+const co = require('co')
+
+/** @lends cursorMixin */
+function cursorMixin (BaseClass) {
+  class IterateMixed extends BaseClass {
+    get $$cursorMixed () {
+      return true
+    }
+
+    /**
+     * Create cursor to cursor
+     * @param {string} resourceName - Name of resource
+     * @param {Object} [options={}] - Optional settings
+     * @returns {Object} {Promise.<[Symbol.iterator], function>} Iterable cursor
+     */
+    cursor (resourceName, options = {}) {
+      const s = this
+      let { filter = {} } = options
+      return co(function * () {
+        let fetch = (page) => s.list(resourceName, { filter, page })
+        let { meta } = yield fetch({ number: 1, size: 0 })
+        let { total } = meta
+        if (typeof total === 'undefined') {
+          throw new Error('Failed to create cursor')
+        }
+        return {
+          length: total,
+          [Symbol.iterator] () {
+            let number = 0
+            return {
+              next () {
+                number += 1
+                let done = number > total
+                let page = { number, size: 1 }
+                return {
+                  value: !done && (() => fetch(page).then(({ entities }) => entities[ 0 ])),
+                  done
+                }
+              }
+            }
+          }
+        }
+      })
+    }
+  }
+  return IterateMixed
+}
+
+module.exports = cursorMixin

--- a/lib/mixins/index.js
+++ b/lib/mixins/index.js
@@ -8,5 +8,6 @@
 let d = (module) => module && module.default || module
 
 module.exports = {
-  get bulkMix () { return d(require('./bulk_mix')) }
+  get bulkMix () { return d(require('./bulk_mix')) },
+  get cursorMix () { return d(require('./cursor_mix')) }
 }

--- a/test/cursor_mix_test.js
+++ b/test/cursor_mix_test.js
@@ -1,0 +1,47 @@
+/**
+ * Test case for cursorMix.
+ * Runs with mocha.
+ */
+'use strict'
+
+const cursorMix = require('../lib/mixins/cursor_mix.js')
+const { ok, equal } = require('assert')
+const co = require('co')
+
+describe('cursor-mix', function () {
+  this.timeout(3000)
+
+  before(() => co(function * () {
+
+  }))
+
+  after(() => co(function * () {
+
+  }))
+
+  it('Cursor mix', () => co(function * () {
+    class Listable {
+      list (resourceName, options = {}) {
+        let { filter = {}, page = {} } = options
+        if (page.number > 3) {
+          return Promise.resolve({ entities: [], meta: { total: 3 } })
+        } else {
+          return Promise.resolve({ entities: [ { id: page.number } ], meta: { total: 3 } })
+        }
+      }
+    }
+
+    const CursorMixed = cursorMix(Listable)
+
+    let cursorMixed = new CursorMixed()
+
+    let cursor = yield cursorMixed.cursor('hoge')
+    equal(cursor.length, 3)
+    for (let fetch of cursor) {
+      let entity = yield fetch()
+      ok(entity)
+    }
+  }))
+})
+
+/* global describe, before, after, it */


### PR DESCRIPTION
Lump同士のmergeに使う`.cursor()`メソッドを実装した。
JSのiteratorを使い、

```javascript
co(function * () {
  let cursor = yield driver.cursor('products')
  console.log(cursor.length) // -> 100000
  for (let fetch of cursor) {
     let product = yield fetch()
     /* ... */
  }
})
```

のように呼び出せる


https://developer.mozilla.org/en/docs/Web/JavaScript/Guide/Iterators_and_Generators